### PR TITLE
Fix msgpack dependency issue.

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "commander": ">=2.0.0",
     "debug": ">=0.7.3",
     "lodash": ">=2.2.1",
-    "msgpack": ">=0.2.1",
+    "msgpack": "^0.2.1",
     "request": ">=2.27.0",
     "object-emitter": ">=0.0.5",
     "object-settings": ">=0.0.6",


### PR DESCRIPTION
If you try to install node-rabbit-client dependencies it breaks when trying to install the latest msgpack. Staying on the mayor version of msgpack fixes it.